### PR TITLE
Require libzip >= 1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AC_PROG_CC
 # FIXME: Replace `main' with a function in `-lzip':
 #AC_CHECK_LIB([zip], [zip_open])
 
-PKG_CHECK_MODULES([ZIP], [libzip])
+PKG_CHECK_MODULES([ZIP], [libzip >= 1.0])
 PKG_CHECK_MODULES([XML2], [libxml-2.0])
 PKG_CHECK_MODULES([OPENSSL], [openssl])
 PKG_CHECK_MODULES([XMLSEC], [xmlsec1 xmlsec1-openssl])


### PR DESCRIPTION
Most distributions still ship libzip 0.10, but wgtpkg is
using "zip_dir_add()", "ZIP_FL_ENC_*"... which only exist
in more recent libzip >= 1.0.

Make the autotools check more precise in this respect.

Signed-off-by: Manuel Bachmann <manuel.bachmann@iot.bzh>